### PR TITLE
Correcting the behavior of keyboard_hide for ios by replacing how the…

### DIFF
--- a/appium/lib/screen-object.rb
+++ b/appium/lib/screen-object.rb
@@ -200,14 +200,13 @@ module ScreenObject
   end
   alias_method :click_exact_text, :tap_exact_text
 
-  def drag_and_drop_element(source_locator,source_locator_value,target_locator,target_locator_value)
-    l_draggable = driver.find_element(source_locator,source_locator_value)
-    l_droppable = driver.find_element(target_locator,target_locator_value)
-    obj1 = Appium::TouchAction.new
-    obj1.long_press(:x => l_draggable.location.x,:y => l_draggable.location.y)
-        .move_to(:x => l_droppable.location.x,:y => l_droppable.location.y)
-        .release
-        .perform
+  def drag_and_drop_element(source_locator, source_locator_value, target_locator, target_locator_value)
+    loc_drag = driver.find_element(source_locator, source_locator_value).location
+    loc_drop = driver.find_element(target_locator, target_locator_value).location
+    action = Appium::TouchAction.new
+    action = action.long_press(x: loc_drag.x, y: loc_drag.y)
+    action = action.move_to(x: loc_drop.x, y: loc_drop.y)
+    action.release.perform
   end
 
   # Hides the keyboard if is_keyboard_shown.

--- a/appium/lib/screen-object.rb
+++ b/appium/lib/screen-object.rb
@@ -217,7 +217,7 @@ module ScreenObject
   def keyboard_hide
     return unless driver.is_keyboard_shown
 
-    if driver.driver_is_ios?
+    if driver.device_is_ios?
       touch_point(driver.find_element(class: 'XCUIElementTypeKeyboard').location)
     else
       driver.hide_keyboard

--- a/appium/lib/screen-object.rb
+++ b/appium/lib/screen-object.rb
@@ -53,7 +53,7 @@ module ScreenObject
     driver.back
   end
 
-  def wait_until(timeout = 30, message = nil, &block)
+  def wait_until(timeout = 5, message = nil, &block)
     default_wait = driver.default_wait if driver
     driver.no_wait if driver
     wait = Selenium::WebDriver::Wait.new(timeout: timeout, message: message)
@@ -79,6 +79,21 @@ module ScreenObject
     raise("Error during gesture \n Error Details: #{e}")
   end
 
+  # Uses an Appium TouchAction with the described points, potentially with an offset.
+  # Mimics '.click' but does not need an element, but could pass in element.location to do it, or just [100,200]
+  #
+  # @param coordinates [Array] A pair of 2 integers that can be used to describe a point on the screen
+  # @param offset_x    [Integer] How much to the left or right of the point you identified you want to actually touch
+  # @param offset_y    [Integer] How much to the top or bottom of the point you identified you want to actually touch
+  def touch_point(coordinates, offset_x = 0, offset_y = 0)
+    x = coordinates[0] + offset_x
+    y = coordinates[1] + offset_y
+
+    action = Appium::TouchAction.new
+    action.press(x: x, y: y).wait(10).release
+    action.perform
+  end
+
   # Scrolls device screen in a direction
   #
   # @param direction [symbol] The direction to search for an string
@@ -89,12 +104,11 @@ module ScreenObject
     x = size.width / 2
     y = size.height / 2
     loc = case direction
-          when :up then    [x, y, x, (y + (y * distance)), duration]
-          when :down then  [x, y, x, y * distance, duration]
-          when :left then  [x * 0.6, y, x * 0.3, y, duration]
+          when :up    then [x, y, x, (y + (y * distance)), duration]
+          when :down  then [x, y, x, y * distance, duration]
+          when :left  then [x * 0.6, y, x * 0.3, y, duration]
           when :right then [x * 0.3, y, x * 0.6, y, duration]
-          else
-            raise('Only up, down, left and right scrolling are supported')
+          else raise('Only up, down, left and right scrolling are supported')
           end
     gesture(loc)
   end
@@ -150,11 +164,7 @@ module ScreenObject
   # @return          [Boolean]
   def text_visible?(text)
     driver.no_wait if driver
-    if driver.find(text).displayed?
-      true
-    else
-      false
-    end
+    driver.find(text).displayed?
   rescue Selenium::WebDriver::Error::NoSuchElementError
     false
   end
@@ -193,20 +203,31 @@ module ScreenObject
   def drag_and_drop_element(source_locator,source_locator_value,target_locator,target_locator_value)
     l_draggable = driver.find_element(source_locator,source_locator_value)
     l_droppable = driver.find_element(target_locator,target_locator_value)
-    obj1= Appium::TouchAction.new
-    obj1.long_press(:x => l_draggable.location.x,:y => l_draggable.location.y).move_to(:x => l_droppable.location.x,:y => l_droppable.location.y).release.perform
+    obj1 = Appium::TouchAction.new
+    obj1.long_press(:x => l_draggable.location.x,:y => l_draggable.location.y)
+        .move_to(:x => l_droppable.location.x,:y => l_droppable.location.y)
+        .release
+        .perform
   end
 
+  # Hides the keyboard if is_keyboard_shown.
+  #
+  # For ios we built a work-around for the keyboard_close
+  # the basic driver strategies all return nil, so they are not working as intended
+  # https://github.com/appium/ruby_lib/issues/295 <- appium issue related to keyboard.
   def keyboard_hide
-    begin
-      driver.hide_keyboard if driver.is_keyboard_shown
-    rescue
-      false
+    return unless driver.is_keyboard_shown
+
+    if driver.driver_is_ios?
+      touch_point(driver.find_element(class: 'XCUIElementTypeKeyboard').location)
+    else
+      driver.hide_keyboard
     end
+  rescue Selenium::WebDriver::Error::NoSuchElementError
+    raise 'There was an issue locating the keyboard element.'
   end
 
   def wait_for_text(text, timeout = 30)
     wait_until(timeout,"text << #{text} >> is not visible", & ->{driver.find("#{text}").displayed? })
   end
-
 end

--- a/appium/lib/screen-object/version.rb
+++ b/appium/lib/screen-object/version.rb
@@ -1,4 +1,4 @@
 
 module ScreenObject
-  VERSION = '1.0.5'
+  VERSION = '1.0.6'
 end


### PR DESCRIPTION
Some basic Ruby syntax clean up and style changes that make the methods more readable.
I also added the touch_point method to the screen_object.rb file to help with tough to tap elements by conventional means
Changed the keyboard_hide method to use the touch_point for the keyboard class on ios to work_around a known bug.