### PR TITLE
Keyboard hotfix - NEEDS TO MERGE TONIGHT

### DIFF
--- a/appium/lib/screen-object.rb
+++ b/appium/lib/screen-object.rb
@@ -214,15 +214,16 @@ module ScreenObject
   # For ios we built a work-around for the keyboard_close
   # the basic driver strategies all return nil, so they are not working as intended
   # https://github.com/appium/ruby_lib/issues/295 <- appium issue related to keyboard.
-  def keyboard_hide(tries = 3)
+  def keyboard_hide
     return unless driver.is_keyboard_shown
 
     if driver.device_is_ios?
-      touch_point(driver.find_element(class: 'XCUIElementTypeKeyboard').location)
+      # the keyboard always arranges at the bottom of the XML,
+      # the keyboard 'Done' will always be last.
+      driver.find_elements(name: 'Done').last.click
     else
       driver.hide_keyboard
     end
-    tries.zero? ? raise : keyboard_hide(tries -= 1)
   rescue Selenium::WebDriver::Error::NoSuchElementError
     raise 'There was an issue locating the keyboard element.'
   end

--- a/appium/lib/screen-object/version.rb
+++ b/appium/lib/screen-object/version.rb
@@ -1,4 +1,4 @@
 
 module ScreenObject
-  VERSION = '1.0.7'
+  VERSION = '1.0.8'
 end


### PR DESCRIPTION
HOTFIX: browserstack focus doesn't align with the focus on simulators for closed keyboards. this method should fix that issue. It could cause other problems if there are incorrect keyboard implementations from the product.